### PR TITLE
feat: add target field for webpack.

### DIFF
--- a/src/webpack/common.config.js
+++ b/src/webpack/common.config.js
@@ -51,6 +51,7 @@ module.exports = () => {
 
   const commonConfig = {
     entry: config.entryPath,
+    target: config.target,
     output: {
       // 打包输出的文件
       path: config.buildPath,

--- a/src/webpack/config.js
+++ b/src/webpack/config.js
@@ -19,6 +19,7 @@ class Config {
         root: process.cwd(),
         raf: path.resolve(process.cwd(), 'node_modules/raf/'),
       },
+      target: 'web',
       rootPath: process.cwd(),
       entryPath: { index: path.resolve(process.cwd(), 'src/index.tsx') },
       buildPath: path.resolve(process.cwd(), 'build'),


### PR DESCRIPTION
Add 'target' field in webpack config, in order to match different development environment, such as 'electron-render' | 'electron-main'.